### PR TITLE
Add search action listeners

### DIFF
--- a/AccountInfo.java
+++ b/AccountInfo.java
@@ -10,6 +10,10 @@ import javax.swing.JLabel;
 import java.awt.Font;
 import javax.swing.JTextField;
 import javax.swing.JButton;
+import javax.swing.JOptionPane;
+import java.sql.*;
+import java.awt.event.ActionListener;
+import java.awt.event.ActionEvent;
 import javax.swing.JMenuBar;
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
@@ -78,6 +82,31 @@ public class AccountInfo extends JFrame {
 		JButton btnNewButton = new JButton("Search");
 		btnNewButton.setBounds(460, 56, 89, 23);
 		panel.add(btnNewButton);
+                btnNewButton.addActionListener(new ActionListener() {
+                    public void actionPerformed(ActionEvent e) {
+                        String username = textField.getText().trim();
+                        if (username.isEmpty()) {
+                            JOptionPane.showMessageDialog(null, "Please enter a search term.");
+                            return;
+                        }
+                        try {
+                            Class.forName("com.mysql.cj.jdbc.Driver");
+                            try (Connection con = DriverManager.getConnection("jdbc:mysql://localhost:3306/idlecenter", "root", "my1234sl");
+                                 PreparedStatement stmt = con.prepareStatement("SELECT * FROM accountinfo WHERE username = ?")) {
+                                stmt.setString(1, username);
+                                try (ResultSet rs = stmt.executeQuery()) {
+                                    if (rs.next()) {
+                                        JOptionPane.showMessageDialog(null, "Account found for " + username);
+                                    } else {
+                                        JOptionPane.showMessageDialog(null, "No account found for " + username);
+                                    }
+                                }
+                            }
+                        } catch (Exception ex) {
+                            JOptionPane.showMessageDialog(null, "Error: " + ex.getMessage());
+                        }
+                    }
+                });
 		
 		JPanel panel_1 = new JPanel();
 		panel_1.setBounds(0, 102, 608, 372);

--- a/AllFood.java
+++ b/AllFood.java
@@ -10,6 +10,8 @@ import javax.swing.JLabel;
 import java.awt.Font;
 import javax.swing.JTextField;
 import javax.swing.JButton;
+import javax.swing.JOptionPane;
+import java.sql.*;
 import javax.swing.JMenuBar;
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
@@ -77,6 +79,32 @@ public class AllFood extends JFrame {
 		JButton btnNewButton = new JButton("Search");
 		btnNewButton.setBounds(460, 56, 89, 23);
 		panel.add(btnNewButton);
+                btnNewButton.addActionListener(new ActionListener() {
+                    public void actionPerformed(ActionEvent e) {
+                        String text = textField.getText().trim();
+                        if (text.isEmpty()) {
+                            JOptionPane.showMessageDialog(null, "Please enter a search term.");
+                            return;
+                        }
+                        try {
+                            Class.forName("com.mysql.cj.jdbc.Driver");
+                            try (Connection con = DriverManager.getConnection("jdbc:mysql://localhost:3306/idlecenter", "root", "my1234sl");
+                                 PreparedStatement stmt = con.prepareStatement("SELECT * FROM resturant WHERE name = ?")) {
+                                stmt.setString(1, text);
+                                try (ResultSet rs = stmt.executeQuery()) {
+                                    if (rs.next()) {
+                                        Resturant res = new Resturant();
+                                        res.setVisible(true);
+                                    } else {
+                                        JOptionPane.showMessageDialog(null, "No restaurant found for " + text);
+                                    }
+                                }
+                            }
+                        } catch (Exception ex) {
+                            JOptionPane.showMessageDialog(null, "Error: " + ex.getMessage());
+                        }
+                    }
+                });
 		
 		JPanel panel_1 = new JPanel();
 		panel_1.setBounds(0, 99, 627, 332);

--- a/Cart.java
+++ b/Cart.java
@@ -10,6 +10,10 @@ import javax.swing.JLabel;
 import java.awt.Font;
 import javax.swing.JTextField;
 import javax.swing.JButton;
+import javax.swing.JOptionPane;
+import java.sql.*;
+import java.awt.event.ActionListener;
+import java.awt.event.ActionEvent;
 import javax.swing.JMenuBar;
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
@@ -79,6 +83,31 @@ public class Cart extends JFrame {
 		JButton btnNewButton = new JButton("Search");
 		btnNewButton.setBounds(460, 56, 89, 23);
 		panel.add(btnNewButton);
+                btnNewButton.addActionListener(new ActionListener() {
+                    public void actionPerformed(ActionEvent e) {
+                        String user = textField.getText().trim();
+                        if (user.isEmpty()) {
+                            JOptionPane.showMessageDialog(null, "Please enter a search term.");
+                            return;
+                        }
+                        try {
+                            Class.forName("com.mysql.cj.jdbc.Driver");
+                            try (Connection con = DriverManager.getConnection("jdbc:mysql://localhost:3306/idlecenter", "root", "my1234sl");
+                                 PreparedStatement stmt = con.prepareStatement("SELECT * FROM cart WHERE username = ?")) {
+                                stmt.setString(1, user);
+                                try (ResultSet rs = stmt.executeQuery()) {
+                                    if (rs.next()) {
+                                        JOptionPane.showMessageDialog(null, "Cart entries found for " + user);
+                                    } else {
+                                        JOptionPane.showMessageDialog(null, "No cart entries found for " + user);
+                                    }
+                                }
+                            }
+                        } catch (Exception ex) {
+                            JOptionPane.showMessageDialog(null, "Error: " + ex.getMessage());
+                        }
+                    }
+                });
 		
 		JPanel panel_1 = new JPanel();
 		panel_1.setBounds(0, 98, 641, 513);

--- a/Feedbeck.java
+++ b/Feedbeck.java
@@ -10,6 +10,10 @@ import javax.swing.JLabel;
 import java.awt.Font;
 import javax.swing.JTextField;
 import javax.swing.JButton;
+import javax.swing.JOptionPane;
+import java.sql.*;
+import java.awt.event.ActionListener;
+import java.awt.event.ActionEvent;
 import javax.swing.JMenuBar;
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
@@ -80,6 +84,31 @@ public class Feedbeck extends JFrame {
 		JButton btnNewButton = new JButton("Search");
 		btnNewButton.setBounds(460, 56, 89, 23);
 		panel.add(btnNewButton);
+                btnNewButton.addActionListener(new ActionListener() {
+                    public void actionPerformed(ActionEvent e) {
+                        String user = textField.getText().trim();
+                        if (user.isEmpty()) {
+                            JOptionPane.showMessageDialog(null, "Please enter a search term.");
+                            return;
+                        }
+                        try {
+                            Class.forName("com.mysql.cj.jdbc.Driver");
+                            try (Connection con = DriverManager.getConnection("jdbc:mysql://localhost:3306/idlecenter", "root", "my1234sl");
+                                 PreparedStatement stmt = con.prepareStatement("SELECT * FROM feedbeck WHERE username = ?")) {
+                                stmt.setString(1, user);
+                                try (ResultSet rs = stmt.executeQuery()) {
+                                    if (rs.next()) {
+                                        JOptionPane.showMessageDialog(null, "Feedback found for " + user);
+                                    } else {
+                                        JOptionPane.showMessageDialog(null, "No feedback found for " + user);
+                                    }
+                                }
+                            }
+                        } catch (Exception ex) {
+                            JOptionPane.showMessageDialog(null, "Error: " + ex.getMessage());
+                        }
+                    }
+                });
 		
 		JPanel panel_1 = new JPanel();
 		panel_1.setBounds(0, 102, 654, 372);

--- a/Food.java
+++ b/Food.java
@@ -10,6 +10,8 @@ import javax.swing.JLabel;
 import java.awt.Font;
 import javax.swing.JTextField;
 import javax.swing.JButton;
+import javax.swing.JOptionPane;
+import java.sql.*;
 import javax.swing.JMenuBar;
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
@@ -78,6 +80,31 @@ public class Food extends JFrame {
 		JButton btnNewButton = new JButton("Search");
 		btnNewButton.setBounds(460, 56, 89, 23);
 		panel.add(btnNewButton);
+                btnNewButton.addActionListener(new ActionListener() {
+                    public void actionPerformed(ActionEvent e) {
+                        String text = textField.getText().trim();
+                        if (text.isEmpty()) {
+                            JOptionPane.showMessageDialog(null, "Please enter a search term.");
+                            return;
+                        }
+                        try {
+                            Class.forName("com.mysql.cj.jdbc.Driver");
+                            try (Connection con = DriverManager.getConnection("jdbc:mysql://localhost:3306/idlecenter", "root", "my1234sl");
+                                 PreparedStatement stmt = con.prepareStatement("SELECT * FROM food WHERE name = ?")) {
+                                stmt.setString(1, text);
+                                try (ResultSet rs = stmt.executeQuery()) {
+                                    if (rs.next()) {
+                                        JOptionPane.showMessageDialog(null, "Food found: " + text);
+                                    } else {
+                                        JOptionPane.showMessageDialog(null, "No food found for " + text);
+                                    }
+                                }
+                            }
+                        } catch (Exception ex) {
+                            JOptionPane.showMessageDialog(null, "Error: " + ex.getMessage());
+                        }
+                    }
+                });
 		
 		JPanel panel_1 = new JPanel();
 		panel_1.setBounds(0, 99, 608, 496);

--- a/PackageInfo.java
+++ b/PackageInfo.java
@@ -10,6 +10,10 @@ import javax.swing.JLabel;
 import java.awt.Font;
 import javax.swing.JTextField;
 import javax.swing.JButton;
+import javax.swing.JOptionPane;
+import java.sql.*;
+import java.awt.event.ActionListener;
+import java.awt.event.ActionEvent;
 import javax.swing.JMenuBar;
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
@@ -79,6 +83,31 @@ public class PackageInfo extends JFrame {
 		JButton btnNewButton = new JButton("Search");
 		btnNewButton.setBounds(460, 56, 89, 23);
 		panel.add(btnNewButton);
+                btnNewButton.addActionListener(new ActionListener() {
+                    public void actionPerformed(ActionEvent e) {
+                        String user = textField.getText().trim();
+                        if (user.isEmpty()) {
+                            JOptionPane.showMessageDialog(null, "Please enter a search term.");
+                            return;
+                        }
+                        try {
+                            Class.forName("com.mysql.cj.jdbc.Driver");
+                            try (Connection con = DriverManager.getConnection("jdbc:mysql://localhost:3306/idlecenter", "root", "my1234sl");
+                                 PreparedStatement stmt = con.prepareStatement("SELECT * FROM packageinfo WHERE username = ?")) {
+                                stmt.setString(1, user);
+                                try (ResultSet rs = stmt.executeQuery()) {
+                                    if (rs.next()) {
+                                        JOptionPane.showMessageDialog(null, "Package info found for " + user);
+                                    } else {
+                                        JOptionPane.showMessageDialog(null, "No package info found for " + user);
+                                    }
+                                }
+                            }
+                        } catch (Exception ex) {
+                            JOptionPane.showMessageDialog(null, "Error: " + ex.getMessage());
+                        }
+                    }
+                });
 		
 		JPanel panel_1 = new JPanel();
 		panel_1.setBounds(0, 102, 626, 372);

--- a/Resturant.java
+++ b/Resturant.java
@@ -10,6 +10,8 @@ import javax.swing.JLabel;
 import java.awt.Font;
 import javax.swing.JTextField;
 import javax.swing.JButton;
+import javax.swing.JOptionPane;
+import java.sql.*;
 import javax.swing.JMenuBar;
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
@@ -75,6 +77,32 @@ public class Resturant extends JFrame {
 		JButton btnNewButton = new JButton("Search");
 		btnNewButton.setBounds(460, 56, 89, 23);
 		panel.add(btnNewButton);
+                btnNewButton.addActionListener(new ActionListener() {
+                    public void actionPerformed(ActionEvent e) {
+                        String text = textField.getText().trim();
+                        if (text.isEmpty()) {
+                            JOptionPane.showMessageDialog(null, "Please enter a search term.");
+                            return;
+                        }
+                        try {
+                            Class.forName("com.mysql.cj.jdbc.Driver");
+                            try (Connection con = DriverManager.getConnection("jdbc:mysql://localhost:3306/idlecenter", "root", "my1234sl");
+                                 PreparedStatement stmt = con.prepareStatement("SELECT * FROM food WHERE name = ?")) {
+                                stmt.setString(1, text);
+                                try (ResultSet rs = stmt.executeQuery()) {
+                                    if (rs.next()) {
+                                        Food food = new Food();
+                                        food.setVisible(true);
+                                    } else {
+                                        JOptionPane.showMessageDialog(null, "No food found for " + text);
+                                    }
+                                }
+                            }
+                        } catch (Exception ex) {
+                            JOptionPane.showMessageDialog(null, "Error: " + ex.getMessage());
+                        }
+                    }
+                });
 		
 		JPanel panel_1 = new JPanel();
 		panel_1.setBounds(0, 99, 608, 496);

--- a/UserInfo.java
+++ b/UserInfo.java
@@ -10,6 +10,10 @@ import javax.swing.JLabel;
 import java.awt.Font;
 import javax.swing.JTextField;
 import javax.swing.JButton;
+import javax.swing.JOptionPane;
+import java.sql.*;
+import java.awt.event.ActionListener;
+import java.awt.event.ActionEvent;
 import javax.swing.JMenuBar;
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
@@ -78,6 +82,31 @@ public class UserInfo extends JFrame {
 		JButton btnNewButton = new JButton("Search");
 		btnNewButton.setBounds(460, 56, 89, 23);
 		panel.add(btnNewButton);
+                btnNewButton.addActionListener(new ActionListener() {
+                    public void actionPerformed(ActionEvent e) {
+                        String user = textField.getText().trim();
+                        if (user.isEmpty()) {
+                            JOptionPane.showMessageDialog(null, "Please enter a search term.");
+                            return;
+                        }
+                        try {
+                            Class.forName("com.mysql.cj.jdbc.Driver");
+                            try (Connection con = DriverManager.getConnection("jdbc:mysql://localhost:3306/idlecenter", "root", "my1234sl");
+                                 PreparedStatement stmt = con.prepareStatement("SELECT * FROM userinfo WHERE username = ?")) {
+                                stmt.setString(1, user);
+                                try (ResultSet rs = stmt.executeQuery()) {
+                                    if (rs.next()) {
+                                        JOptionPane.showMessageDialog(null, "User found: " + user);
+                                    } else {
+                                        JOptionPane.showMessageDialog(null, "No user found for " + user);
+                                    }
+                                }
+                            }
+                        } catch (Exception ex) {
+                            JOptionPane.showMessageDialog(null, "Error: " + ex.getMessage());
+                        }
+                    }
+                });
 		
 		JPanel panel_1 = new JPanel();
 		panel_1.setBounds(0, 102, 608, 372);


### PR DESCRIPTION
## Summary
- wire up Search buttons across screens to run database lookups via PreparedStatement
- navigate or report when records are missing using dialog prompts

## Testing
- `javac *.java`


------
https://chatgpt.com/codex/tasks/task_e_68a868826ee88323aca9f75e61aec390