### PR TITLE
Add navigation listeners to menus

### DIFF
--- a/AccountInfo.java
+++ b/AccountInfo.java
@@ -90,15 +90,16 @@ public class AccountInfo extends JFrame {
 		menuBar.setBounds(0, 0, 608, 37);
 		panel_1.add(menuBar);
 		
-		JMenu mnNewMenu_3 = new JMenu("User Information");
-		mnNewMenu_3.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				UserInfo user=new UserInfo();
-				user.setVisible(true);
-			}
-		});
-		menuBar.add(mnNewMenu_3);
+                JMenu mnNewMenu_3 = new JMenu("User Information");
+                mnNewMenu_3.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                UserInfo user=new UserInfo();
+                                user.setVisible(true);
+                                dispose();
+                        }
+                });
+                menuBar.add(mnNewMenu_3);
 		
                 JMenu mnNewMenu = new JMenu("Resturant");
                 menuBar.add(mnNewMenu);
@@ -126,15 +127,16 @@ public class AccountInfo extends JFrame {
                });
                mnNewMenu_1.add(mntmNewMenuItem_3);
 		
-		JMenu mnNewMenu_2 = new JMenu("Account Information");
-		mnNewMenu_2.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				AccountInfo acc=new AccountInfo();
-				acc.setVisible(true);
-			}
-		});
-		menuBar.add(mnNewMenu_2);
+                JMenu mnNewMenu_2 = new JMenu("Account Information");
+                mnNewMenu_2.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                AccountInfo acc=new AccountInfo();
+                                acc.setVisible(true);
+                                dispose();
+                        }
+                });
+                menuBar.add(mnNewMenu_2);
 		
                JMenu mnNewMenu_4 = new JMenu("Package Details");
                mnNewMenu_4.addMouseListener(new MouseAdapter() {
@@ -147,48 +149,52 @@ public class AccountInfo extends JFrame {
                });
                menuBar.add(mnNewMenu_4);
 		
-		JMenu mnNewMenu_5 = new JMenu("Log out");
-		mnNewMenu_5.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				Login login=new Login();
-				login.setVisible(true);
-			}
-		});
-		menuBar.add(mnNewMenu_5);
+                JMenu mnNewMenu_5 = new JMenu("Log out");
+                mnNewMenu_5.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                Login login=new Login();
+                                login.setVisible(true);
+                                dispose();
+                        }
+                });
+                menuBar.add(mnNewMenu_5);
 		
 		JMenu mnNewMenu_6 = new JMenu("Feedbeck");
 		menuBar.add(mnNewMenu_6);
 		
-		JMenuItem mntmNewMenuItem_4 = new JMenuItem("Feedbeck Resturant");
-		mntmNewMenuItem_4.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				Feedbeck feedbeck=new Feedbeck();
-				feedbeck.setVisible(true);
-			}
-		});
-		mnNewMenu_6.add(mntmNewMenuItem_4);
+                JMenuItem mntmNewMenuItem_4 = new JMenuItem("Feedbeck Resturant");
+                mntmNewMenuItem_4.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                Feedbeck feedbeck=new Feedbeck();
+                                feedbeck.setVisible(true);
+                                dispose();
+                        }
+                });
+                mnNewMenu_6.add(mntmNewMenuItem_4);
 		
-		JMenu mnNewMenu_7 = new JMenu("Cart");
-		mnNewMenu_7.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				Cart cart=new Cart();
-				cart.setVisible(true);
-			}
-		});
-		menuBar.add(mnNewMenu_7);
+                JMenu mnNewMenu_7 = new JMenu("Cart");
+                mnNewMenu_7.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                Cart cart=new Cart();
+                                cart.setVisible(true);
+                                dispose();
+                        }
+                });
+                menuBar.add(mnNewMenu_7);
 		
-		JMenu mnNewMenu_8 = new JMenu("Home");
-		mnNewMenu_8.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				HomePage home=new HomePage();
-				home.setVisible(true);
-			}
-		});
-		menuBar.add(mnNewMenu_8);
+                JMenu mnNewMenu_8 = new JMenu("Home");
+                mnNewMenu_8.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                HomePage home=new HomePage();
+                                home.setVisible(true);
+                                dispose();
+                        }
+                });
+                menuBar.add(mnNewMenu_8);
 		
 		JLabel lblNewLabel_2 = new JLabel("User Name");
 		lblNewLabel_2.setBounds(270, 48, 89, 14);

--- a/AccountInfo.java
+++ b/AccountInfo.java
@@ -20,6 +20,8 @@ import javax.swing.table.DefaultTableModel;
 import javax.swing.border.CompoundBorder;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.ActionEvent;
 
 public class AccountInfo extends JFrame {
 
@@ -98,17 +100,31 @@ public class AccountInfo extends JFrame {
 		});
 		menuBar.add(mnNewMenu_3);
 		
-		JMenu mnNewMenu = new JMenu("Resturant");
-		menuBar.add(mnNewMenu);
-		
-		JMenuItem mntmNewMenuItem_1 = new JMenuItem("All");
-		mnNewMenu.add(mntmNewMenuItem_1);
+                JMenu mnNewMenu = new JMenu("Resturant");
+                menuBar.add(mnNewMenu);
+
+               JMenuItem mntmNewMenuItem_1 = new JMenuItem("All");
+               mntmNewMenuItem_1.addActionListener(new ActionListener() {
+                       public void actionPerformed(ActionEvent e) {
+                               AllResturant all = new AllResturant();
+                               all.setVisible(true);
+                               dispose();
+                       }
+               });
+               mnNewMenu.add(mntmNewMenuItem_1);
 		
 		JMenu mnNewMenu_1 = new JMenu("Food");
 		menuBar.add(mnNewMenu_1);
 		
-		JMenuItem mntmNewMenuItem_3 = new JMenuItem("All");
-		mnNewMenu_1.add(mntmNewMenuItem_3);
+               JMenuItem mntmNewMenuItem_3 = new JMenuItem("All");
+               mntmNewMenuItem_3.addActionListener(new ActionListener() {
+                       public void actionPerformed(ActionEvent e) {
+                               AllFood all = new AllFood();
+                               all.setVisible(true);
+                               dispose();
+                       }
+               });
+               mnNewMenu_1.add(mntmNewMenuItem_3);
 		
 		JMenu mnNewMenu_2 = new JMenu("Account Information");
 		mnNewMenu_2.addMouseListener(new MouseAdapter() {
@@ -120,8 +136,16 @@ public class AccountInfo extends JFrame {
 		});
 		menuBar.add(mnNewMenu_2);
 		
-		JMenu mnNewMenu_4 = new JMenu("Package Details");
-		menuBar.add(mnNewMenu_4);
+               JMenu mnNewMenu_4 = new JMenu("Package Details");
+               mnNewMenu_4.addMouseListener(new MouseAdapter() {
+                       @Override
+                       public void mouseClicked(MouseEvent e) {
+                               PackageInfo pac = new PackageInfo();
+                               pac.setVisible(true);
+                               dispose();
+                       }
+               });
+               menuBar.add(mnNewMenu_4);
 		
 		JMenu mnNewMenu_5 = new JMenu("Log out");
 		mnNewMenu_5.addMouseListener(new MouseAdapter() {

--- a/AllFood.java
+++ b/AllFood.java
@@ -87,15 +87,16 @@ public class AllFood extends JFrame {
 		menuBar.setBounds(0, 0, 627, 37);
 		panel_1.add(menuBar);
 		
-		JMenu mnNewMenu_3 = new JMenu("User Information");
-		mnNewMenu_3.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				UserInfo user=new UserInfo();
-				user.setVisible(true);
-			}
-		});
-		menuBar.add(mnNewMenu_3);
+                JMenu mnNewMenu_3 = new JMenu("User Information");
+                mnNewMenu_3.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                UserInfo user=new UserInfo();
+                                user.setVisible(true);
+                                dispose();
+                        }
+                });
+                menuBar.add(mnNewMenu_3);
 		
                 JMenu mnNewMenu = new JMenu("Resturant");
                 menuBar.add(mnNewMenu);
@@ -123,89 +124,97 @@ public class AllFood extends JFrame {
                });
                mnNewMenu_1.add(mntmNewMenuItem_3);
 		
-		JMenu mnNewMenu_2 = new JMenu("Account Information");
-		mnNewMenu_2.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				AccountInfo acc=new AccountInfo();
-				acc.setVisible(true);
-			}
-		});
-		menuBar.add(mnNewMenu_2);
+                JMenu mnNewMenu_2 = new JMenu("Account Information");
+                mnNewMenu_2.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                AccountInfo acc=new AccountInfo();
+                                acc.setVisible(true);
+                                dispose();
+                        }
+                });
+                menuBar.add(mnNewMenu_2);
 		
-		JMenu mnNewMenu_4 = new JMenu("Package Details");
-		mnNewMenu_4.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				PackageInfo pac=new PackageInfo();
-				pac.setVisible(true);
-			}
-		});
-		menuBar.add(mnNewMenu_4);
+                JMenu mnNewMenu_4 = new JMenu("Package Details");
+                mnNewMenu_4.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                PackageInfo pac=new PackageInfo();
+                                pac.setVisible(true);
+                                dispose();
+                        }
+                });
+                menuBar.add(mnNewMenu_4);
 		
-		JMenu mnNewMenu_5 = new JMenu("Log out");
-		mnNewMenu_5.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				Login login=new Login();
-				login.setVisible(true);
-			}
-		});
-		menuBar.add(mnNewMenu_5);
+                JMenu mnNewMenu_5 = new JMenu("Log out");
+                mnNewMenu_5.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                Login login=new Login();
+                                login.setVisible(true);
+                                dispose();
+                        }
+                });
+                menuBar.add(mnNewMenu_5);
 		
 		JMenu mnNewMenu_6 = new JMenu("Feedbeck");
 		menuBar.add(mnNewMenu_6);
 		
-		JMenuItem mntmNewMenuItem_4 = new JMenuItem("Feedbeck Resturant");
-		mntmNewMenuItem_4.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				Feedbeck feedbeck=new Feedbeck();
-				feedbeck.setVisible(true);
-			}
-		});
-		mnNewMenu_6.add(mntmNewMenuItem_4);
+                JMenuItem mntmNewMenuItem_4 = new JMenuItem("Feedbeck Resturant");
+                mntmNewMenuItem_4.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                Feedbeck feedbeck=new Feedbeck();
+                                feedbeck.setVisible(true);
+                                dispose();
+                        }
+                });
+                mnNewMenu_6.add(mntmNewMenuItem_4);
 		
-		JMenu mnNewMenu_7 = new JMenu("Cart");
-		mnNewMenu_7.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				Cart cart=new Cart();
-				cart.setVisible(true);
-			}
-		});
-		menuBar.add(mnNewMenu_7);
+                JMenu mnNewMenu_7 = new JMenu("Cart");
+                mnNewMenu_7.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                Cart cart=new Cart();
+                                cart.setVisible(true);
+                                dispose();
+                        }
+                });
+                menuBar.add(mnNewMenu_7);
 		
-		JMenu mnNewMenu_8 = new JMenu("Home");
-		mnNewMenu_8.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				HomePage home=new HomePage();
-				home.setVisible(true);
-			}
-		});
-		mnNewMenu_8.addActionListener(new ActionListener() {
-			public void actionPerformed(ActionEvent e) {
-				HomePage home=new HomePage();
-				home.setVisible(true);
-			}
-		});
-		menuBar.add(mnNewMenu_8);
+                JMenu mnNewMenu_8 = new JMenu("Home");
+                mnNewMenu_8.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                HomePage home=new HomePage();
+                                home.setVisible(true);
+                                dispose();
+                        }
+                });
+                mnNewMenu_8.addActionListener(new ActionListener() {
+                        public void actionPerformed(ActionEvent e) {
+                                HomePage home=new HomePage();
+                                home.setVisible(true);
+                                dispose();
+                        }
+                });
+                menuBar.add(mnNewMenu_8);
 		
 		JLabel lblNewLabel_2 = new JLabel("Resturant List");
 		lblNewLabel_2.setBounds(270, 48, 89, 14);
 		panel_1.add(lblNewLabel_2);
 		
-		JPanel panel_2 = new JPanel();
-		panel_2.setBounds(38, 127, 151, 140);
-		panel_2.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				Resturant res = new Resturant();
-				res.setVisible(true);
-			}
-		});
-		panel_2.setBackground(new Color(192, 192, 192));
+                JPanel panel_2 = new JPanel();
+                panel_2.setBounds(38, 127, 151, 140);
+                panel_2.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                Resturant res = new Resturant();
+                                res.setVisible(true);
+                                dispose();
+                        }
+                });
+                panel_2.setBackground(new Color(192, 192, 192));
 		panel_1.add(panel_2);
 		panel_2.setLayout(null);
 		

--- a/AllFood.java
+++ b/AllFood.java
@@ -97,17 +97,31 @@ public class AllFood extends JFrame {
 		});
 		menuBar.add(mnNewMenu_3);
 		
-		JMenu mnNewMenu = new JMenu("Resturant");
-		menuBar.add(mnNewMenu);
-		
-		JMenuItem mntmNewMenuItem_1 = new JMenuItem("All");
-		mnNewMenu.add(mntmNewMenuItem_1);
+                JMenu mnNewMenu = new JMenu("Resturant");
+                menuBar.add(mnNewMenu);
+
+               JMenuItem mntmNewMenuItem_1 = new JMenuItem("All");
+               mntmNewMenuItem_1.addActionListener(new ActionListener() {
+                       public void actionPerformed(ActionEvent e) {
+                               AllResturant all = new AllResturant();
+                               all.setVisible(true);
+                               dispose();
+                       }
+               });
+               mnNewMenu.add(mntmNewMenuItem_1);
 		
 		JMenu mnNewMenu_1 = new JMenu("Food");
 		menuBar.add(mnNewMenu_1);
 		
-		JMenuItem mntmNewMenuItem_3 = new JMenuItem("All");
-		mnNewMenu_1.add(mntmNewMenuItem_3);
+               JMenuItem mntmNewMenuItem_3 = new JMenuItem("All");
+               mntmNewMenuItem_3.addActionListener(new ActionListener() {
+                       public void actionPerformed(ActionEvent e) {
+                               AllFood all = new AllFood();
+                               all.setVisible(true);
+                               dispose();
+                       }
+               });
+               mnNewMenu_1.add(mntmNewMenuItem_3);
 		
 		JMenu mnNewMenu_2 = new JMenu("Account Information");
 		mnNewMenu_2.addMouseListener(new MouseAdapter() {

--- a/AllResturant.java
+++ b/AllResturant.java
@@ -97,17 +97,31 @@ public class AllResturant extends JFrame {
 		});
 		menuBar.add(mnNewMenu_3);
 		
-		JMenu mnNewMenu = new JMenu("Resturant");
-		menuBar.add(mnNewMenu);
-		
-		JMenuItem mntmNewMenuItem_1 = new JMenuItem("All");
-		mnNewMenu.add(mntmNewMenuItem_1);
+                JMenu mnNewMenu = new JMenu("Resturant");
+                menuBar.add(mnNewMenu);
+
+               JMenuItem mntmNewMenuItem_1 = new JMenuItem("All");
+               mntmNewMenuItem_1.addActionListener(new ActionListener() {
+                       public void actionPerformed(ActionEvent e) {
+                               AllResturant all = new AllResturant();
+                               all.setVisible(true);
+                               dispose();
+                       }
+               });
+               mnNewMenu.add(mntmNewMenuItem_1);
 		
 		JMenu mnNewMenu_1 = new JMenu("Food");
 		menuBar.add(mnNewMenu_1);
 		
-		JMenuItem mntmNewMenuItem_3 = new JMenuItem("All");
-		mnNewMenu_1.add(mntmNewMenuItem_3);
+               JMenuItem mntmNewMenuItem_3 = new JMenuItem("All");
+               mntmNewMenuItem_3.addActionListener(new ActionListener() {
+                       public void actionPerformed(ActionEvent e) {
+                               AllFood all = new AllFood();
+                               all.setVisible(true);
+                               dispose();
+                       }
+               });
+               mnNewMenu_1.add(mntmNewMenuItem_3);
 		
 		JMenu mnNewMenu_2 = new JMenu("Account Information");
 		mnNewMenu_2.addMouseListener(new MouseAdapter() {

--- a/AllResturant.java
+++ b/AllResturant.java
@@ -87,15 +87,16 @@ public class AllResturant extends JFrame {
 		menuBar.setBounds(0, 0, 629, 37);
 		panel_1.add(menuBar);
 		
-		JMenu mnNewMenu_3 = new JMenu("User Information");
-		mnNewMenu_3.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				UserInfo user=new UserInfo();
-				user.setVisible(true);
-			}
-		});
-		menuBar.add(mnNewMenu_3);
+                JMenu mnNewMenu_3 = new JMenu("User Information");
+                mnNewMenu_3.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                UserInfo user=new UserInfo();
+                                user.setVisible(true);
+                                dispose();
+                        }
+                });
+                menuBar.add(mnNewMenu_3);
 		
                 JMenu mnNewMenu = new JMenu("Resturant");
                 menuBar.add(mnNewMenu);
@@ -123,74 +124,81 @@ public class AllResturant extends JFrame {
                });
                mnNewMenu_1.add(mntmNewMenuItem_3);
 		
-		JMenu mnNewMenu_2 = new JMenu("Account Information");
-		mnNewMenu_2.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				AccountInfo acc=new AccountInfo();
-				acc.setVisible(true);
-			}
-		});
-		menuBar.add(mnNewMenu_2);
+                JMenu mnNewMenu_2 = new JMenu("Account Information");
+                mnNewMenu_2.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                AccountInfo acc=new AccountInfo();
+                                acc.setVisible(true);
+                                dispose();
+                        }
+                });
+                menuBar.add(mnNewMenu_2);
 		
-		JMenu mnNewMenu_4 = new JMenu("Package Details");
-		mnNewMenu_4.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				PackageInfo pac=new PackageInfo();
-				pac.setVisible(true);
-			}
-		});
-		menuBar.add(mnNewMenu_4);
+                JMenu mnNewMenu_4 = new JMenu("Package Details");
+                mnNewMenu_4.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                PackageInfo pac=new PackageInfo();
+                                pac.setVisible(true);
+                                dispose();
+                        }
+                });
+                menuBar.add(mnNewMenu_4);
 		
-		JMenu mnNewMenu_5 = new JMenu("Log out");
-		mnNewMenu_5.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				Login login=new Login();
-				login.setVisible(true);
-			}
-		});
-		menuBar.add(mnNewMenu_5);
+                JMenu mnNewMenu_5 = new JMenu("Log out");
+                mnNewMenu_5.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                Login login=new Login();
+                                login.setVisible(true);
+                                dispose();
+                        }
+                });
+                menuBar.add(mnNewMenu_5);
 		
 		JMenu mnNewMenu_6 = new JMenu("Feedbeck");
 		menuBar.add(mnNewMenu_6);
 		
-		JMenuItem mntmNewMenuItem_4 = new JMenuItem("Feedbeck Resturant");
-		mntmNewMenuItem_4.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				Feedbeck feedbeck=new Feedbeck();
-				feedbeck.setVisible(true);
-			}
-		});
-		mnNewMenu_6.add(mntmNewMenuItem_4);
+                JMenuItem mntmNewMenuItem_4 = new JMenuItem("Feedbeck Resturant");
+                mntmNewMenuItem_4.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                Feedbeck feedbeck=new Feedbeck();
+                                feedbeck.setVisible(true);
+                                dispose();
+                        }
+                });
+                mnNewMenu_6.add(mntmNewMenuItem_4);
 		
-		JMenu mnNewMenu_7 = new JMenu("Cart");
-		mnNewMenu_7.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				Cart cart=new Cart();
-				cart.setVisible(true);
-			}
-		});
-		menuBar.add(mnNewMenu_7);
+                JMenu mnNewMenu_7 = new JMenu("Cart");
+                mnNewMenu_7.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                Cart cart=new Cart();
+                                cart.setVisible(true);
+                                dispose();
+                        }
+                });
+                menuBar.add(mnNewMenu_7);
 		
-		JMenu mnNewMenu_8 = new JMenu("Home");
-		mnNewMenu_8.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				HomePage home=new HomePage();
-				home.setVisible(true);
-			}
-		});
-		mnNewMenu_8.addActionListener(new ActionListener() {
-			public void actionPerformed(ActionEvent e) {
-				HomePage home=new HomePage();
-				home.setVisible(true);
-			}
-		});
-		menuBar.add(mnNewMenu_8);
+                JMenu mnNewMenu_8 = new JMenu("Home");
+                mnNewMenu_8.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                HomePage home=new HomePage();
+                                home.setVisible(true);
+                                dispose();
+                        }
+                });
+                mnNewMenu_8.addActionListener(new ActionListener() {
+                        public void actionPerformed(ActionEvent e) {
+                                HomePage home=new HomePage();
+                                home.setVisible(true);
+                                dispose();
+                        }
+                });
+                menuBar.add(mnNewMenu_8);
 		
 		JLabel lblNewLabel_2 = new JLabel("Food List");
 		lblNewLabel_2.setBounds(270, 48, 89, 14);

--- a/Cart.java
+++ b/Cart.java
@@ -91,15 +91,16 @@ public class Cart extends JFrame {
 		menuBar.setBounds(0, 0, 630, 37);
 		panel_1.add(menuBar);
 		
-		JMenu mnNewMenu_3 = new JMenu("User Information");
-		mnNewMenu_3.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				UserInfo user=new UserInfo();
-				user.setVisible(true);
-			}
-		});
-		menuBar.add(mnNewMenu_3);
+                JMenu mnNewMenu_3 = new JMenu("User Information");
+                mnNewMenu_3.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                UserInfo user=new UserInfo();
+                                user.setVisible(true);
+                                dispose();
+                        }
+                });
+                menuBar.add(mnNewMenu_3);
 		
                 JMenu mnNewMenu = new JMenu("Resturant");
                 menuBar.add(mnNewMenu);
@@ -127,35 +128,38 @@ public class Cart extends JFrame {
                });
                mnNewMenu_1.add(mntmNewMenuItem_3);
 		
-		JMenu mnNewMenu_2 = new JMenu("Account Information");
-		mnNewMenu_2.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				AccountInfo acc=new AccountInfo();
-				acc.setVisible(true);
-			}
-		});
-		menuBar.add(mnNewMenu_2);
+                JMenu mnNewMenu_2 = new JMenu("Account Information");
+                mnNewMenu_2.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                AccountInfo acc=new AccountInfo();
+                                acc.setVisible(true);
+                                dispose();
+                        }
+                });
+                menuBar.add(mnNewMenu_2);
 		
-		JMenu mnNewMenu_4 = new JMenu("Package Details");
-		mnNewMenu_4.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				PackageInfo pac=new PackageInfo();
-				pac.setVisible(true);
-			}
-		});
-		menuBar.add(mnNewMenu_4);
+                JMenu mnNewMenu_4 = new JMenu("Package Details");
+                mnNewMenu_4.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                PackageInfo pac=new PackageInfo();
+                                pac.setVisible(true);
+                                dispose();
+                        }
+                });
+                menuBar.add(mnNewMenu_4);
 		
-		JMenu mnNewMenu_5 = new JMenu("Log out");
-		mnNewMenu_5.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				Login login=new Login();
-				login.setVisible(true);
-			}
-		});
-		menuBar.add(mnNewMenu_5);
+                JMenu mnNewMenu_5 = new JMenu("Log out");
+                mnNewMenu_5.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                Login login=new Login();
+                                login.setVisible(true);
+                                dispose();
+                        }
+                });
+                menuBar.add(mnNewMenu_5);
 		
 		JMenu mnNewMenu_6 = new JMenu("Feedbeck");
 		menuBar.add(mnNewMenu_6);
@@ -173,15 +177,16 @@ public class Cart extends JFrame {
 		JMenu mnNewMenu_7 = new JMenu("Cart");
 		menuBar.add(mnNewMenu_7);
 		
-		JMenu mnNewMenu_8 = new JMenu("Home");
-		mnNewMenu_8.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				HomePage home=new HomePage();
-				home.setVisible(true);
-			}
-		});
-		menuBar.add(mnNewMenu_8);
+                JMenu mnNewMenu_8 = new JMenu("Home");
+                mnNewMenu_8.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                HomePage home=new HomePage();
+                                home.setVisible(true);
+                                dispose();
+                        }
+                });
+                menuBar.add(mnNewMenu_8);
 		
 		JLabel lblNewLabel_2 = new JLabel("Cart");
 		lblNewLabel_2.setBounds(270, 48, 89, 14);

--- a/Cart.java
+++ b/Cart.java
@@ -20,6 +20,8 @@ import javax.swing.table.DefaultTableModel;
 import javax.swing.border.CompoundBorder;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.ActionEvent;
 
 public class Cart extends JFrame {
 
@@ -99,17 +101,31 @@ public class Cart extends JFrame {
 		});
 		menuBar.add(mnNewMenu_3);
 		
-		JMenu mnNewMenu = new JMenu("Resturant");
-		menuBar.add(mnNewMenu);
-		
-		JMenuItem mntmNewMenuItem_1 = new JMenuItem("All");
-		mnNewMenu.add(mntmNewMenuItem_1);
+                JMenu mnNewMenu = new JMenu("Resturant");
+                menuBar.add(mnNewMenu);
+
+               JMenuItem mntmNewMenuItem_1 = new JMenuItem("All");
+               mntmNewMenuItem_1.addActionListener(new ActionListener() {
+                       public void actionPerformed(ActionEvent e) {
+                               AllResturant all = new AllResturant();
+                               all.setVisible(true);
+                               dispose();
+                       }
+               });
+               mnNewMenu.add(mntmNewMenuItem_1);
 		
 		JMenu mnNewMenu_1 = new JMenu("Food");
 		menuBar.add(mnNewMenu_1);
 		
-		JMenuItem mntmNewMenuItem_3 = new JMenuItem("All");
-		mnNewMenu_1.add(mntmNewMenuItem_3);
+               JMenuItem mntmNewMenuItem_3 = new JMenuItem("All");
+               mntmNewMenuItem_3.addActionListener(new ActionListener() {
+                       public void actionPerformed(ActionEvent e) {
+                               AllFood all = new AllFood();
+                               all.setVisible(true);
+                               dispose();
+                       }
+               });
+               mnNewMenu_1.add(mntmNewMenuItem_3);
 		
 		JMenu mnNewMenu_2 = new JMenu("Account Information");
 		mnNewMenu_2.addMouseListener(new MouseAdapter() {
@@ -144,8 +160,15 @@ public class Cart extends JFrame {
 		JMenu mnNewMenu_6 = new JMenu("Feedbeck");
 		menuBar.add(mnNewMenu_6);
 		
-		JMenuItem mntmNewMenuItem_4 = new JMenuItem("Feedbeck Resturant");
-		mnNewMenu_6.add(mntmNewMenuItem_4);
+               JMenuItem mntmNewMenuItem_4 = new JMenuItem("Feedbeck Resturant");
+               mntmNewMenuItem_4.addActionListener(new ActionListener() {
+                       public void actionPerformed(ActionEvent e) {
+                               Feedbeck feedbeck = new Feedbeck();
+                               feedbeck.setVisible(true);
+                               dispose();
+                       }
+               });
+               mnNewMenu_6.add(mntmNewMenuItem_4);
 		
 		JMenu mnNewMenu_7 = new JMenu("Cart");
 		menuBar.add(mnNewMenu_7);

--- a/Feedbeck.java
+++ b/Feedbeck.java
@@ -92,15 +92,16 @@ public class Feedbeck extends JFrame {
 		menuBar.setBounds(0, 0, 644, 37);
 		panel_1.add(menuBar);
 		
-		JMenu mnNewMenu_3 = new JMenu("User Information");
-		mnNewMenu_3.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				UserInfo user=new UserInfo();
-				user.setVisible(true);
-			}
-		});
-		menuBar.add(mnNewMenu_3);
+                JMenu mnNewMenu_3 = new JMenu("User Information");
+                mnNewMenu_3.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                UserInfo user=new UserInfo();
+                                user.setVisible(true);
+                                dispose();
+                        }
+                });
+                menuBar.add(mnNewMenu_3);
 		
                 JMenu mnNewMenu = new JMenu("Resturant");
                 menuBar.add(mnNewMenu);
@@ -128,15 +129,16 @@ public class Feedbeck extends JFrame {
                });
                mnNewMenu_1.add(mntmNewMenuItem_3);
 		
-		JMenu mnNewMenu_2 = new JMenu("Account Information");
-		mnNewMenu_2.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				AccountInfo acc=new AccountInfo();
-				acc.setVisible(true);
-			}
-		});
-		menuBar.add(mnNewMenu_2);
+                JMenu mnNewMenu_2 = new JMenu("Account Information");
+                mnNewMenu_2.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                AccountInfo acc=new AccountInfo();
+                                acc.setVisible(true);
+                                dispose();
+                        }
+                });
+                menuBar.add(mnNewMenu_2);
 		
                JMenu mnNewMenu_4 = new JMenu("Package Details");
                mnNewMenu_4.addMouseListener(new MouseAdapter() {
@@ -149,48 +151,51 @@ public class Feedbeck extends JFrame {
                });
                menuBar.add(mnNewMenu_4);
 		
-		JMenu mnNewMenu_5 = new JMenu("Log out");
-		mnNewMenu_5.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				Login login=new Login();
-				login.setVisible(true);
-			}
-		});
-		menuBar.add(mnNewMenu_5);
+                JMenu mnNewMenu_5 = new JMenu("Log out");
+                mnNewMenu_5.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                Login login=new Login();
+                                login.setVisible(true);
+                                dispose();
+                        }
+                });
+                menuBar.add(mnNewMenu_5);
 		
 		JMenu mnNewMenu_6 = new JMenu("Feedbeck");
 		menuBar.add(mnNewMenu_6);
 		
-               JMenuItem mntmNewMenuItem_4 = new JMenuItem("Feedbeck Resturant");
-               mntmNewMenuItem_4.addActionListener(new ActionListener() {
-                       public void actionPerformed(ActionEvent e) {
-                               Feedbeck feed = new Feedbeck();
-                               feed.setVisible(true);
-                               dispose();
-                       }
-               });
-               mnNewMenu_6.add(mntmNewMenuItem_4);
+                JMenuItem mntmNewMenuItem_4 = new JMenuItem("Feedbeck Resturant");
+                mntmNewMenuItem_4.addActionListener(new ActionListener() {
+                        public void actionPerformed(ActionEvent e) {
+                                Feedbeck feed = new Feedbeck();
+                                feed.setVisible(true);
+                                dispose();
+                        }
+                });
+                mnNewMenu_6.add(mntmNewMenuItem_4);
 		
-		JMenu mnNewMenu_7 = new JMenu("Cart");
-		mnNewMenu_7.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				Cart cart=new Cart();
-				cart.setVisible(true);
-			}
-		});
-		menuBar.add(mnNewMenu_7);
+                JMenu mnNewMenu_7 = new JMenu("Cart");
+                mnNewMenu_7.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                Cart cart=new Cart();
+                                cart.setVisible(true);
+                                dispose();
+                        }
+                });
+                menuBar.add(mnNewMenu_7);
 		
-		JMenu mnNewMenu_8 = new JMenu("Home");
-		mnNewMenu_8.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				HomePage home=new HomePage();
-				home.setVisible(true);
-			}
-		});
-		menuBar.add(mnNewMenu_8);
+                JMenu mnNewMenu_8 = new JMenu("Home");
+                mnNewMenu_8.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                HomePage home=new HomePage();
+                                home.setVisible(true);
+                                dispose();
+                        }
+                });
+                menuBar.add(mnNewMenu_8);
 		
 		JLabel lblNewLabel_2 = new JLabel("User Name");
 		lblNewLabel_2.setBounds(270, 48, 89, 14);

--- a/Feedbeck.java
+++ b/Feedbeck.java
@@ -20,6 +20,8 @@ import javax.swing.table.DefaultTableModel;
 import javax.swing.border.CompoundBorder;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.ActionEvent;
 
 public class Feedbeck extends JFrame {
 
@@ -100,17 +102,31 @@ public class Feedbeck extends JFrame {
 		});
 		menuBar.add(mnNewMenu_3);
 		
-		JMenu mnNewMenu = new JMenu("Resturant");
-		menuBar.add(mnNewMenu);
-		
-		JMenuItem mntmNewMenuItem_1 = new JMenuItem("All");
-		mnNewMenu.add(mntmNewMenuItem_1);
+                JMenu mnNewMenu = new JMenu("Resturant");
+                menuBar.add(mnNewMenu);
+
+               JMenuItem mntmNewMenuItem_1 = new JMenuItem("All");
+               mntmNewMenuItem_1.addActionListener(new ActionListener() {
+                       public void actionPerformed(ActionEvent e) {
+                               AllResturant all = new AllResturant();
+                               all.setVisible(true);
+                               dispose();
+                       }
+               });
+               mnNewMenu.add(mntmNewMenuItem_1);
 		
 		JMenu mnNewMenu_1 = new JMenu("Food");
 		menuBar.add(mnNewMenu_1);
 		
-		JMenuItem mntmNewMenuItem_3 = new JMenuItem("All");
-		mnNewMenu_1.add(mntmNewMenuItem_3);
+               JMenuItem mntmNewMenuItem_3 = new JMenuItem("All");
+               mntmNewMenuItem_3.addActionListener(new ActionListener() {
+                       public void actionPerformed(ActionEvent e) {
+                               AllFood all = new AllFood();
+                               all.setVisible(true);
+                               dispose();
+                       }
+               });
+               mnNewMenu_1.add(mntmNewMenuItem_3);
 		
 		JMenu mnNewMenu_2 = new JMenu("Account Information");
 		mnNewMenu_2.addMouseListener(new MouseAdapter() {
@@ -122,8 +138,16 @@ public class Feedbeck extends JFrame {
 		});
 		menuBar.add(mnNewMenu_2);
 		
-		JMenu mnNewMenu_4 = new JMenu("Package Details");
-		menuBar.add(mnNewMenu_4);
+               JMenu mnNewMenu_4 = new JMenu("Package Details");
+               mnNewMenu_4.addMouseListener(new MouseAdapter() {
+                       @Override
+                       public void mouseClicked(MouseEvent e) {
+                               PackageInfo pac = new PackageInfo();
+                               pac.setVisible(true);
+                               dispose();
+                       }
+               });
+               menuBar.add(mnNewMenu_4);
 		
 		JMenu mnNewMenu_5 = new JMenu("Log out");
 		mnNewMenu_5.addMouseListener(new MouseAdapter() {
@@ -138,8 +162,15 @@ public class Feedbeck extends JFrame {
 		JMenu mnNewMenu_6 = new JMenu("Feedbeck");
 		menuBar.add(mnNewMenu_6);
 		
-		JMenuItem mntmNewMenuItem_4 = new JMenuItem("Feedbeck Resturant");
-		mnNewMenu_6.add(mntmNewMenuItem_4);
+               JMenuItem mntmNewMenuItem_4 = new JMenuItem("Feedbeck Resturant");
+               mntmNewMenuItem_4.addActionListener(new ActionListener() {
+                       public void actionPerformed(ActionEvent e) {
+                               Feedbeck feed = new Feedbeck();
+                               feed.setVisible(true);
+                               dispose();
+                       }
+               });
+               mnNewMenu_6.add(mntmNewMenuItem_4);
 		
 		JMenu mnNewMenu_7 = new JMenu("Cart");
 		mnNewMenu_7.addMouseListener(new MouseAdapter() {

--- a/PackageInfo.java
+++ b/PackageInfo.java
@@ -20,6 +20,8 @@ import javax.swing.table.DefaultTableModel;
 import javax.swing.border.CompoundBorder;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.ActionEvent;
 
 public class PackageInfo extends JFrame {
 
@@ -99,17 +101,31 @@ public class PackageInfo extends JFrame {
 		});
 		menuBar.add(mnNewMenu_3);
 		
-		JMenu mnNewMenu = new JMenu("Resturant");
-		menuBar.add(mnNewMenu);
-		
-		JMenuItem mntmNewMenuItem_1 = new JMenuItem("All");
-		mnNewMenu.add(mntmNewMenuItem_1);
+                JMenu mnNewMenu = new JMenu("Resturant");
+                menuBar.add(mnNewMenu);
+
+               JMenuItem mntmNewMenuItem_1 = new JMenuItem("All");
+               mntmNewMenuItem_1.addActionListener(new ActionListener() {
+                       public void actionPerformed(ActionEvent e) {
+                               AllResturant all = new AllResturant();
+                               all.setVisible(true);
+                               dispose();
+                       }
+               });
+               mnNewMenu.add(mntmNewMenuItem_1);
 		
 		JMenu mnNewMenu_1 = new JMenu("Food");
 		menuBar.add(mnNewMenu_1);
 		
-		JMenuItem mntmNewMenuItem_3 = new JMenuItem("All");
-		mnNewMenu_1.add(mntmNewMenuItem_3);
+               JMenuItem mntmNewMenuItem_3 = new JMenuItem("All");
+               mntmNewMenuItem_3.addActionListener(new ActionListener() {
+                       public void actionPerformed(ActionEvent e) {
+                               AllFood all = new AllFood();
+                               all.setVisible(true);
+                               dispose();
+                       }
+               });
+               mnNewMenu_1.add(mntmNewMenuItem_3);
 		
 		JMenu mnNewMenu_2 = new JMenu("Account Information");
 		mnNewMenu_2.addMouseListener(new MouseAdapter() {
@@ -121,8 +137,16 @@ public class PackageInfo extends JFrame {
 		});
 		menuBar.add(mnNewMenu_2);
 		
-		JMenu mnNewMenu_4 = new JMenu("Package Details");
-		menuBar.add(mnNewMenu_4);
+               JMenu mnNewMenu_4 = new JMenu("Package Details");
+               mnNewMenu_4.addMouseListener(new MouseAdapter() {
+                       @Override
+                       public void mouseClicked(MouseEvent e) {
+                               PackageInfo pac = new PackageInfo();
+                               pac.setVisible(true);
+                               dispose();
+                       }
+               });
+               menuBar.add(mnNewMenu_4);
 		
 		JMenu mnNewMenu_5 = new JMenu("Log out");
 		mnNewMenu_5.addMouseListener(new MouseAdapter() {

--- a/PackageInfo.java
+++ b/PackageInfo.java
@@ -91,15 +91,16 @@ public class PackageInfo extends JFrame {
 		menuBar.setBounds(0, 0, 626, 37);
 		panel_1.add(menuBar);
 		
-		JMenu mnNewMenu_3 = new JMenu("User Information");
-		mnNewMenu_3.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				UserInfo user=new UserInfo();
-				user.setVisible(true);
-			}
-		});
-		menuBar.add(mnNewMenu_3);
+                JMenu mnNewMenu_3 = new JMenu("User Information");
+                mnNewMenu_3.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                UserInfo user=new UserInfo();
+                                user.setVisible(true);
+                                dispose();
+                        }
+                });
+                menuBar.add(mnNewMenu_3);
 		
                 JMenu mnNewMenu = new JMenu("Resturant");
                 menuBar.add(mnNewMenu);
@@ -127,15 +128,16 @@ public class PackageInfo extends JFrame {
                });
                mnNewMenu_1.add(mntmNewMenuItem_3);
 		
-		JMenu mnNewMenu_2 = new JMenu("Account Information");
-		mnNewMenu_2.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				AccountInfo acc=new AccountInfo();
-				acc.setVisible(true);
-			}
-		});
-		menuBar.add(mnNewMenu_2);
+                JMenu mnNewMenu_2 = new JMenu("Account Information");
+                mnNewMenu_2.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                AccountInfo acc=new AccountInfo();
+                                acc.setVisible(true);
+                                dispose();
+                        }
+                });
+                menuBar.add(mnNewMenu_2);
 		
                JMenu mnNewMenu_4 = new JMenu("Package Details");
                mnNewMenu_4.addMouseListener(new MouseAdapter() {
@@ -148,48 +150,52 @@ public class PackageInfo extends JFrame {
                });
                menuBar.add(mnNewMenu_4);
 		
-		JMenu mnNewMenu_5 = new JMenu("Log out");
-		mnNewMenu_5.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				Login login=new Login();
-				login.setVisible(true);
-			}
-		});
-		menuBar.add(mnNewMenu_5);
+                JMenu mnNewMenu_5 = new JMenu("Log out");
+                mnNewMenu_5.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                Login login=new Login();
+                                login.setVisible(true);
+                                dispose();
+                        }
+                });
+                menuBar.add(mnNewMenu_5);
 		
 		JMenu mnNewMenu_6 = new JMenu("Feedbeck");
 		menuBar.add(mnNewMenu_6);
 		
-		JMenuItem mntmNewMenuItem_4 = new JMenuItem("Feedbeck Resturant");
-		mntmNewMenuItem_4.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				Feedbeck feedbeck=new Feedbeck();
-				feedbeck.setVisible(true);
-			}
-		});
-		mnNewMenu_6.add(mntmNewMenuItem_4);
+                JMenuItem mntmNewMenuItem_4 = new JMenuItem("Feedbeck Resturant");
+                mntmNewMenuItem_4.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                Feedbeck feedbeck=new Feedbeck();
+                                feedbeck.setVisible(true);
+                                dispose();
+                        }
+                });
+                mnNewMenu_6.add(mntmNewMenuItem_4);
 		
-		JMenu mnNewMenu_7 = new JMenu("Cart");
-		mnNewMenu_7.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				Cart cart=new Cart();
-				cart.setVisible(true);
-			}
-		});
-		menuBar.add(mnNewMenu_7);
+                JMenu mnNewMenu_7 = new JMenu("Cart");
+                mnNewMenu_7.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                Cart cart=new Cart();
+                                cart.setVisible(true);
+                                dispose();
+                        }
+                });
+                menuBar.add(mnNewMenu_7);
 		
-		JMenu mnNewMenu_8 = new JMenu("Home");
-		mnNewMenu_8.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				HomePage home=new HomePage();
-				home.setVisible(true);
-			}
-		});
-		menuBar.add(mnNewMenu_8);
+                JMenu mnNewMenu_8 = new JMenu("Home");
+                mnNewMenu_8.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                HomePage home=new HomePage();
+                                home.setVisible(true);
+                                dispose();
+                        }
+                });
+                menuBar.add(mnNewMenu_8);
 		
 		JLabel lblNewLabel_2 = new JLabel("User Name");
 		lblNewLabel_2.setBounds(270, 48, 89, 14);

--- a/Resturant.java
+++ b/Resturant.java
@@ -144,38 +144,41 @@ public class Resturant extends JFrame {
                });
                menuBar.add(mnNewMenu_4);
 		
-		JMenu mnNewMenu_5 = new JMenu("Log out");
-		mnNewMenu_5.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				Login login=new Login();
-				login.setVisible(true);
-			}
-		});
-		menuBar.add(mnNewMenu_5);
+                JMenu mnNewMenu_5 = new JMenu("Log out");
+                mnNewMenu_5.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                Login login=new Login();
+                                login.setVisible(true);
+                                dispose();
+                        }
+                });
+                menuBar.add(mnNewMenu_5);
 		
 		JMenu mnNewMenu_6 = new JMenu("Feedbeck");
 		menuBar.add(mnNewMenu_6);
 		
-		JMenuItem mntmNewMenuItem_4 = new JMenuItem("Feedbeck Resturant");
-		mntmNewMenuItem_4.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				Feedbeck feedbeck=new Feedbeck();
-				feedbeck.setVisible(true);
-			}
-		});
-		mnNewMenu_6.add(mntmNewMenuItem_4);
+                JMenuItem mntmNewMenuItem_4 = new JMenuItem("Feedbeck Resturant");
+                mntmNewMenuItem_4.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                Feedbeck feedbeck=new Feedbeck();
+                                feedbeck.setVisible(true);
+                                dispose();
+                        }
+                });
+                mnNewMenu_6.add(mntmNewMenuItem_4);
 		
-		JMenu mnNewMenu_7 = new JMenu("Cart");
-		mnNewMenu_7.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				Cart cart=new Cart();
-				cart.setVisible(true);
-			}
-		});
-		menuBar.add(mnNewMenu_7);
+                JMenu mnNewMenu_7 = new JMenu("Cart");
+                mnNewMenu_7.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                Cart cart=new Cart();
+                                cart.setVisible(true);
+                                dispose();
+                        }
+                });
+                menuBar.add(mnNewMenu_7);
 		
 		JLabel lblNewLabel_2 = new JLabel("Lalbagh Kitchen");
 		lblNewLabel_2.setBounds(224, 48, 89, 14);
@@ -209,17 +212,18 @@ public class Resturant extends JFrame {
 		lblNewLabel_4.setBounds(240, 11, 49, 14);
 		panel_3.add(lblNewLabel_4);
 		
-		JPanel panel_4 = new JPanel();
-		panel_4.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				Food food=new Food();
-				food.setVisible(true);
-			}
-		});
-		panel_4.setBounds(36, 66, 125, 146);
-		panel_3.add(panel_4);
-		panel_4.setLayout(null);
+                JPanel panel_4 = new JPanel();
+                panel_4.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                Food food=new Food();
+                                food.setVisible(true);
+                                dispose();
+                        }
+                });
+                panel_4.setBounds(36, 66, 125, 146);
+                panel_3.add(panel_4);
+                panel_4.setLayout(null);
 		
 		JLabel lblNewLabel_5 = new JLabel("Rice");
 		lblNewLabel_5.setBounds(33, 121, 49, 14);

--- a/Resturant.java
+++ b/Resturant.java
@@ -85,46 +85,64 @@ public class Resturant extends JFrame {
 		menuBar.setBounds(0, 0, 608, 37);
 		panel_1.add(menuBar);
 		
-		JMenu mnNewMenu_3 = new JMenu("User Information");
-		menuBar.add(mnNewMenu_3);
+               JMenu mnNewMenu_3 = new JMenu("User Information");
+               mnNewMenu_3.addMouseListener(new MouseAdapter() {
+                       @Override
+                       public void mouseClicked(MouseEvent e) {
+                               UserInfo user = new UserInfo();
+                               user.setVisible(true);
+                               dispose();
+                       }
+               });
+               menuBar.add(mnNewMenu_3);
 		
 		JMenu mnNewMenu = new JMenu("Resturant");
 		menuBar.add(mnNewMenu);
 		
-		JMenuItem mntmNewMenuItem_1 = new JMenuItem("All");
-		mntmNewMenuItem_1.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				AllFood allfood=new AllFood();
-				allfood.setVisible(true);
-			}
-		});
-		mnNewMenu.add(mntmNewMenuItem_1);
+               JMenuItem mntmNewMenuItem_1 = new JMenuItem("All");
+               mntmNewMenuItem_1.addActionListener(new ActionListener() {
+                       public void actionPerformed(ActionEvent e) {
+                               AllResturant all = new AllResturant();
+                               all.setVisible(true);
+                               dispose();
+                       }
+               });
+               mnNewMenu.add(mntmNewMenuItem_1);
 		
 		JMenu mnNewMenu_1 = new JMenu("Food");
 		menuBar.add(mnNewMenu_1);
 		
-		JMenuItem mntmNewMenuItem_3 = new JMenuItem("All");
-		mntmNewMenuItem_3.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				AllFood allfood=new AllFood();
-				allfood.setVisible(true);
-			}
-		});
-		mntmNewMenuItem_3.addActionListener(new ActionListener() {
-			public void actionPerformed(ActionEvent e) {
-				AllFood allfood=new AllFood();
-				allfood.setVisible(true);
-			}
-		});
-		mnNewMenu_1.add(mntmNewMenuItem_3);
+               JMenuItem mntmNewMenuItem_3 = new JMenuItem("All");
+               mntmNewMenuItem_3.addActionListener(new ActionListener() {
+                       public void actionPerformed(ActionEvent e) {
+                               AllFood allfood = new AllFood();
+                               allfood.setVisible(true);
+                               dispose();
+                       }
+               });
+               mnNewMenu_1.add(mntmNewMenuItem_3);
 		
-		JMenu mnNewMenu_2 = new JMenu("Account Information");
-		menuBar.add(mnNewMenu_2);
+               JMenu mnNewMenu_2 = new JMenu("Account Information");
+               mnNewMenu_2.addMouseListener(new MouseAdapter() {
+                       @Override
+                       public void mouseClicked(MouseEvent e) {
+                               AccountInfo acc = new AccountInfo();
+                               acc.setVisible(true);
+                               dispose();
+                       }
+               });
+               menuBar.add(mnNewMenu_2);
 		
-		JMenu mnNewMenu_4 = new JMenu("Package Details");
-		menuBar.add(mnNewMenu_4);
+               JMenu mnNewMenu_4 = new JMenu("Package Details");
+               mnNewMenu_4.addMouseListener(new MouseAdapter() {
+                       @Override
+                       public void mouseClicked(MouseEvent e) {
+                               PackageInfo pac = new PackageInfo();
+                               pac.setVisible(true);
+                               dispose();
+                       }
+               });
+               menuBar.add(mnNewMenu_4);
 		
 		JMenu mnNewMenu_5 = new JMenu("Log out");
 		mnNewMenu_5.addMouseListener(new MouseAdapter() {

--- a/UserInfo.java
+++ b/UserInfo.java
@@ -90,8 +90,16 @@ public class UserInfo extends JFrame {
 		menuBar.setBounds(0, 0, 608, 37);
 		panel_1.add(menuBar);
 		
-		JMenu mnNewMenu_3 = new JMenu("User Information");
-		menuBar.add(mnNewMenu_3);
+                JMenu mnNewMenu_3 = new JMenu("User Information");
+                mnNewMenu_3.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                UserInfo user = new UserInfo();
+                                user.setVisible(true);
+                                dispose();
+                        }
+                });
+                menuBar.add(mnNewMenu_3);
 		
                 JMenu mnNewMenu = new JMenu("Resturant");
                 menuBar.add(mnNewMenu);
@@ -119,68 +127,74 @@ public class UserInfo extends JFrame {
                });
                mnNewMenu_1.add(mntmNewMenuItem_3);
 		
-		JMenu mnNewMenu_2 = new JMenu("Account Information");
-		mnNewMenu_2.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				AccountInfo acc=new AccountInfo();
-				acc.setVisible(true);
-			}
-		});
-		menuBar.add(mnNewMenu_2);
+                JMenu mnNewMenu_2 = new JMenu("Account Information");
+                mnNewMenu_2.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                AccountInfo acc=new AccountInfo();
+                                acc.setVisible(true);
+                                dispose();
+                        }
+                });
+                menuBar.add(mnNewMenu_2);
 		
-		JMenu mnNewMenu_4 = new JMenu("Package Details");
-		mnNewMenu_4.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				PackageInfo pac=new PackageInfo();
-				pac.setVisible(true);
-			}
-		});
-		menuBar.add(mnNewMenu_4);
+                JMenu mnNewMenu_4 = new JMenu("Package Details");
+                mnNewMenu_4.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                PackageInfo pac=new PackageInfo();
+                                pac.setVisible(true);
+                                dispose();
+                        }
+                });
+                menuBar.add(mnNewMenu_4);
 		
-		JMenu mnNewMenu_5 = new JMenu("Log out");
-		mnNewMenu_5.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				Login login=new Login();
-				login.setVisible(true);
-			}
-		});
-		menuBar.add(mnNewMenu_5);
+                JMenu mnNewMenu_5 = new JMenu("Log out");
+                mnNewMenu_5.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                Login login=new Login();
+                                login.setVisible(true);
+                                dispose();
+                        }
+                });
+                menuBar.add(mnNewMenu_5);
 		
 		JMenu mnNewMenu_6 = new JMenu("Feedbeck");
 		menuBar.add(mnNewMenu_6);
 		
-		JMenuItem mntmNewMenuItem_4 = new JMenuItem("Feedbeck Resturant");
-		mntmNewMenuItem_4.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				Feedbeck feedbeck=new Feedbeck();
-				feedbeck.setVisible(true);
-			}
-		});
-		mnNewMenu_6.add(mntmNewMenuItem_4);
+                JMenuItem mntmNewMenuItem_4 = new JMenuItem("Feedbeck Resturant");
+                mntmNewMenuItem_4.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                Feedbeck feedbeck=new Feedbeck();
+                                feedbeck.setVisible(true);
+                                dispose();
+                        }
+                });
+                mnNewMenu_6.add(mntmNewMenuItem_4);
 		
-		JMenu mnNewMenu_7 = new JMenu("Cart");
-		mnNewMenu_7.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				Cart cart=new Cart();
-				cart.setVisible(true);
-			}
-		});
-		menuBar.add(mnNewMenu_7);
+                JMenu mnNewMenu_7 = new JMenu("Cart");
+                mnNewMenu_7.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                Cart cart=new Cart();
+                                cart.setVisible(true);
+                                dispose();
+                        }
+                });
+                menuBar.add(mnNewMenu_7);
 		
-		JMenu mnNewMenu_8 = new JMenu("Home");
-		mnNewMenu_8.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				HomePage home=new HomePage();
-				home.setVisible(true);
-			}
-		});
-		menuBar.add(mnNewMenu_8);
+                JMenu mnNewMenu_8 = new JMenu("Home");
+                mnNewMenu_8.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                HomePage home=new HomePage();
+                                home.setVisible(true);
+                                dispose();
+                        }
+                });
+                menuBar.add(mnNewMenu_8);
 		
 		JLabel lblNewLabel_2 = new JLabel("User Name");
 		lblNewLabel_2.setBounds(270, 48, 89, 14);

--- a/UserInfo.java
+++ b/UserInfo.java
@@ -20,6 +20,8 @@ import javax.swing.table.DefaultTableModel;
 import javax.swing.border.CompoundBorder;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.ActionEvent;
 
 public class UserInfo extends JFrame {
 
@@ -91,17 +93,31 @@ public class UserInfo extends JFrame {
 		JMenu mnNewMenu_3 = new JMenu("User Information");
 		menuBar.add(mnNewMenu_3);
 		
-		JMenu mnNewMenu = new JMenu("Resturant");
-		menuBar.add(mnNewMenu);
-		
-		JMenuItem mntmNewMenuItem_1 = new JMenuItem("All");
-		mnNewMenu.add(mntmNewMenuItem_1);
+                JMenu mnNewMenu = new JMenu("Resturant");
+                menuBar.add(mnNewMenu);
+
+               JMenuItem mntmNewMenuItem_1 = new JMenuItem("All");
+               mntmNewMenuItem_1.addActionListener(new ActionListener() {
+                       public void actionPerformed(ActionEvent e) {
+                               AllResturant all = new AllResturant();
+                               all.setVisible(true);
+                               dispose();
+                       }
+               });
+               mnNewMenu.add(mntmNewMenuItem_1);
 		
 		JMenu mnNewMenu_1 = new JMenu("Food");
 		menuBar.add(mnNewMenu_1);
 		
-		JMenuItem mntmNewMenuItem_3 = new JMenuItem("All");
-		mnNewMenu_1.add(mntmNewMenuItem_3);
+               JMenuItem mntmNewMenuItem_3 = new JMenuItem("All");
+               mntmNewMenuItem_3.addActionListener(new ActionListener() {
+                       public void actionPerformed(ActionEvent e) {
+                               AllFood all = new AllFood();
+                               all.setVisible(true);
+                               dispose();
+                       }
+               });
+               mnNewMenu_1.add(mntmNewMenuItem_3);
 		
 		JMenu mnNewMenu_2 = new JMenu("Account Information");
 		mnNewMenu_2.addMouseListener(new MouseAdapter() {


### PR DESCRIPTION
## Summary
- Add missing ActionListener/MouseListener handlers for menu items across AccountInfo, AllFood, AllResturant, Cart, Feedbeck, PackageInfo, UserInfo, and Resturant.
- Launch the corresponding frames from each menu and dispose the current window to prevent stacking.

## Testing
- `javac -d build *.java`


------
https://chatgpt.com/codex/tasks/task_e_68a86883f0ac8323a6e4dd8137eb3be3