### PR TITLE
Add Home menu to Food and Resturant screens

### DIFF
--- a/Food.java
+++ b/Food.java
@@ -181,15 +181,26 @@ public class Food extends JFrame {
 				cart.setVisible(true);
 			}
 		});
-		mnNewMenu_7.addActionListener(new ActionListener() {
-			public void actionPerformed(ActionEvent e) {
-				Cart cart=new Cart();
-				cart.setVisible(true);
-			}
-		});
-		menuBar.add(mnNewMenu_7);
-		
-		JLabel lblNewLabel_2 = new JLabel("Rice");
+                mnNewMenu_7.addActionListener(new ActionListener() {
+                        public void actionPerformed(ActionEvent e) {
+                                Cart cart=new Cart();
+                                cart.setVisible(true);
+                        }
+                });
+                menuBar.add(mnNewMenu_7);
+
+                JMenu mnNewMenu_8 = new JMenu("Home");
+                mnNewMenu_8.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                HomePage home=new HomePage();
+                                home.setVisible(true);
+                                dispose();
+                        }
+                });
+                menuBar.add(mnNewMenu_8);
+
+                JLabel lblNewLabel_2 = new JLabel("Rice");
 		lblNewLabel_2.setBounds(270, 48, 89, 14);
 		panel_1.add(lblNewLabel_2);
 		

--- a/Resturant.java
+++ b/Resturant.java
@@ -150,16 +150,27 @@ public class Resturant extends JFrame {
 		mnNewMenu_6.add(mntmNewMenuItem_4);
 		
 		JMenu mnNewMenu_7 = new JMenu("Cart");
-		mnNewMenu_7.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				Cart cart=new Cart();
-				cart.setVisible(true);
-			}
-		});
-		menuBar.add(mnNewMenu_7);
-		
-		JLabel lblNewLabel_2 = new JLabel("Lalbagh Kitchen");
+                mnNewMenu_7.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                Cart cart=new Cart();
+                                cart.setVisible(true);
+                        }
+                });
+                menuBar.add(mnNewMenu_7);
+
+                JMenu mnNewMenu_8 = new JMenu("Home");
+                mnNewMenu_8.addMouseListener(new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent e) {
+                                HomePage home=new HomePage();
+                                home.setVisible(true);
+                                dispose();
+                        }
+                });
+                menuBar.add(mnNewMenu_8);
+
+                JLabel lblNewLabel_2 = new JLabel("Lalbagh Kitchen");
 		lblNewLabel_2.setBounds(224, 48, 89, 14);
 		panel_1.add(lblNewLabel_2);
 		


### PR DESCRIPTION
## Summary
- Add Home menu to Food and Resturant pages for quick navigation back to HomePage.

## Testing
- `javac -cp . *.java`


------
https://chatgpt.com/codex/tasks/task_e_68a868894cbc8323a0bf3b622528a170