### PR TITLE
Remove duplicate Feedbeck menu item declaration

### DIFF
--- a/Cart.java
+++ b/Cart.java
@@ -218,25 +218,22 @@ private double accountBalance = 1000.0;
 		menuBar.add(mnNewMenu_6);
 		
 
-               JMenuItem mntmNewMenuItem_4 = new JMenuItem("Feedbeck Resturant");
-               mntmNewMenuItem_4.addActionListener(new ActionListener() {
-                       public void actionPerformed(ActionEvent e) {
-                               Feedbeck feedbeck = new Feedbeck();
-                               feedbeck.setVisible(true);
-                               dispose();
-                       }
-               });
-               mnNewMenu_6.add(mntmNewMenuItem_4);
-
-               JMenuItem mntmNewMenuItem_4 = new JMenuItem("Feedbeck Resturant");
-               mntmNewMenuItem_4.addMouseListener(new MouseAdapter() {
-                       @Override
-                       public void mouseClicked(MouseEvent e) {
-                               Feedbeck feedbeck = new Feedbeck();
-                               feedbeck.setVisible(true);
-                       }
-               });
-               mnNewMenu_6.add(mntmNewMenuItem_4);
+JMenuItem mntmNewMenuItem_4 = new JMenuItem("Feedbeck Resturant");
+mntmNewMenuItem_4.addActionListener(new ActionListener() {
+public void actionPerformed(ActionEvent e) {
+Feedbeck feedbeck = new Feedbeck();
+feedbeck.setVisible(true);
+dispose();
+}
+});
+mntmNewMenuItem_4.addMouseListener(new MouseAdapter() {
+@Override
+public void mouseClicked(MouseEvent e) {
+Feedbeck feedbeck = new Feedbeck();
+feedbeck.setVisible(true);
+}
+});
+mnNewMenu_6.add(mntmNewMenuItem_4);
 
 		
 		JMenu mnNewMenu_7 = new JMenu("Cart");


### PR DESCRIPTION
## Summary
- eliminate duplicate `Feedbeck Resturant` menu item in `Cart` and attach both action and mouse listeners to a single instance

## Testing
- `javac *.java`


------
https://chatgpt.com/codex/tasks/task_e_68a88fc263188323b35d82725ad1b394